### PR TITLE
feat: v0.3.0 Quality Gates — tests, pre-flight, WhatIf standardization

### DIFF
--- a/automation/Remove-ExpiredResources.ps1
+++ b/automation/Remove-ExpiredResources.ps1
@@ -13,15 +13,12 @@
     - Supports -WhatIf for dry runs
     - Skips resources with active resource locks
 
-.PARAMETER DryRun
-    Report what would be deleted without actually deleting.
-
 .PARAMETER OutputPath
     Path to write the action log CSV. Default: ./cleanup-log-{date}.csv
 
 .EXAMPLE
     # See what would be cleaned up
-    .\Remove-ExpiredResources.ps1 -DryRun
+    .\Remove-ExpiredResources.ps1 -WhatIf
 
     # Run for real
     .\Remove-ExpiredResources.ps1
@@ -29,9 +26,6 @@
 
 [CmdletBinding(SupportsShouldProcess)]
 param(
-    [Parameter()]
-    [switch]$DryRun,
-
     [Parameter()]
     [string]$OutputPath = "./cleanup-log-$(Get-Date -Format 'yyyyMMdd-HHmmss').csv"
 )
@@ -62,7 +56,7 @@ $totalSkipped = 0
 
 foreach ($sub in $subscriptions) {
     Write-Log "Processing subscription: $($sub.Name)"
-    Set-AzContext -SubscriptionId $sub.Id | Out-Null
+    Set-AzContext -SubscriptionId $sub.Id -ErrorAction Stop | Out-Null
 
     # Find resources with expired expiry-date tag
     $expiredByTag = Get-AzResource -TagName "expiry-date" | Where-Object {
@@ -115,13 +109,6 @@ foreach ($sub in $subscriptions) {
             continue
         }
 
-        if ($DryRun) {
-            Write-Log "[DRY RUN] Would delete: $($resource.Name) ($($resource.ResourceType))" -Level "DRYRUN"
-            $result.Action = "WouldDelete"
-            $results += $result
-            continue
-        }
-
         if ($PSCmdlet.ShouldProcess($resource.Name, "Delete expired resource")) {
             try {
                 Remove-AzResource -ResourceId $resource.Id -Force -ErrorAction Stop
@@ -133,6 +120,8 @@ foreach ($sub in $subscriptions) {
                 $result.Action = "Failed"
                 $result.Reason = $_.ToString()
             }
+        } else {
+            $result.Action = "WhatIf"
         }
 
         $results += $result

--- a/automation/Test-Prerequisites.ps1
+++ b/automation/Test-Prerequisites.ps1
@@ -1,0 +1,99 @@
+<#
+.SYNOPSIS
+    Pre-flight validation for discovery and cleanup workflows.
+
+.DESCRIPTION
+    Verifies that all prerequisites are met before running discovery or cleanup:
+    - Az module is installed and importable
+    - Azure context is authenticated
+    - Target subscriptions are accessible
+    - Required module versions are available
+
+    Designed to run as the first step in GitHub Actions workflows.
+    Returns exit code 1 if any check fails.
+
+.EXAMPLE
+    .\Test-Prerequisites.ps1
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+$failed = 0
+
+function Write-Check {
+    param([string]$Name, [bool]$Passed, [string]$Detail = "")
+    if ($Passed) {
+        Write-Output "[PASS] $Name $Detail"
+    } else {
+        Write-Output "[FAIL] $Name $Detail"
+        $script:failed++
+    }
+}
+
+# ── Az Module ────────────────────────────────────────────────────────────────
+
+$azModule = Get-Module Az.Accounts -ListAvailable | Sort-Object Version -Descending | Select-Object -First 1
+Write-Check "Az.Accounts module installed" ($null -ne $azModule) $(if ($azModule) { "v$($azModule.Version)" })
+
+$azMonitor = Get-Module Az.Monitor -ListAvailable | Sort-Object Version -Descending | Select-Object -First 1
+Write-Check "Az.Monitor module installed" ($null -ne $azMonitor) $(if ($azMonitor) { "v$($azMonitor.Version)" })
+
+# ── Azure Context ────────────────────────────────────────────────────────────
+
+try {
+    $context = Get-AzContext -ErrorAction Stop
+    $hasContext = $null -ne $context -and $null -ne $context.Account
+    Write-Check "Azure context authenticated" $hasContext $(if ($hasContext) { "as $($context.Account.Id)" })
+} catch {
+    Write-Check "Azure context authenticated" $false "Run Connect-AzAccount first"
+}
+
+# ── Subscription Access ──────────────────────────────────────────────────────
+
+if ($hasContext) {
+    try {
+        $subs = Get-AzSubscription | Where-Object { $_.State -eq "Enabled" }
+        Write-Check "Subscriptions accessible" ($subs.Count -gt 0) "$($subs.Count) enabled subscription(s)"
+
+        foreach ($sub in $subs) {
+            Write-Output "       - $($sub.Name) ($($sub.Id))"
+        }
+    } catch {
+        Write-Check "Subscriptions accessible" $false $_.ToString()
+    }
+}
+
+# ── Resource Graph ───────────────────────────────────────────────────────────
+
+$argModule = Get-Module Az.ResourceGraph -ListAvailable | Sort-Object Version -Descending | Select-Object -First 1
+Write-Check "Az.ResourceGraph module installed" ($null -ne $argModule) $(if ($argModule) { "v$($argModule.Version)" })
+
+# ── ImportExcel (optional) ───────────────────────────────────────────────────
+
+$excelModule = Get-Module ImportExcel -ListAvailable | Sort-Object Version -Descending | Select-Object -First 1
+if ($excelModule) {
+    Write-Check "ImportExcel module (optional)" $true "v$($excelModule.Version)"
+} else {
+    Write-Output "[SKIP] ImportExcel module not installed — XLSX reports will be skipped"
+}
+
+# ── Pester (optional) ────────────────────────────────────────────────────────
+
+$pester = Get-Module Pester -ListAvailable | Sort-Object Version -Descending | Select-Object -First 1
+if ($pester) {
+    Write-Check "Pester module (optional)" $true "v$($pester.Version)"
+} else {
+    Write-Output "[SKIP] Pester module not installed — tests will be skipped"
+}
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+Write-Output ""
+if ($failed -gt 0) {
+    Write-Output "[RESULT] $failed pre-flight check(s) FAILED"
+    exit 1
+} else {
+    Write-Output "[RESULT] All pre-flight checks passed"
+}

--- a/automation/discovery.yml
+++ b/automation/discovery.yml
@@ -38,8 +38,29 @@ permissions:
   id-token: write
 
 jobs:
+  preflight:
+    name: Pre-flight Checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Run Pre-flight Validation
+        uses: azure/powershell@v2
+        with:
+          azPSVersion: latest
+          inlineScript: |
+            & "./automation/Test-Prerequisites.ps1"
+
   discover:
     name: Run Discovery
+    needs: preflight
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/automation/scheduled-cleanup.yml
+++ b/automation/scheduled-cleanup.yml
@@ -35,8 +35,29 @@ env:
   DISCOVERY_PATH: ./discovery
 
 jobs:
+  preflight:
+    name: Pre-flight Checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Run Pre-flight Validation
+        uses: azure/powershell@v2
+        with:
+          azPSVersion: latest
+          inlineScript: |
+            & "./automation/Test-Prerequisites.ps1"
+
   discovery:
     name: Resource Discovery
+    needs: preflight
     runs-on: ubuntu-latest
     if: github.event.schedule == '0 6 * * 1' || github.event.inputs.action == 'discovery-only'
     steps:
@@ -66,6 +87,7 @@ jobs:
 
   cleanup-dry-run:
     name: Cleanup Dry Run
+    needs: preflight
     runs-on: ubuntu-latest
     if: github.event.inputs.action == 'cleanup-dry-run'
     steps:
@@ -83,7 +105,7 @@ jobs:
         with:
           azPSVersion: latest
           inlineScript: |
-            & "${{ env.SCRIPTS_PATH }}/../automation/Remove-ExpiredResources.ps1" -DryRun
+            & "${{ env.SCRIPTS_PATH }}/../automation/Remove-ExpiredResources.ps1" -WhatIf
 
       - name: Dry Run - Empty Resource Groups
         uses: azure/powershell@v2
@@ -94,6 +116,7 @@ jobs:
 
   cleanup-execute:
     name: Cleanup Execute
+    needs: preflight
     runs-on: ubuntu-latest
     if: github.event.inputs.action == 'cleanup-execute'
     environment: production  # Requires manual approval

--- a/tests/Remove-EmptyResourceGroups.Tests.ps1
+++ b/tests/Remove-EmptyResourceGroups.Tests.ps1
@@ -1,0 +1,70 @@
+BeforeAll {
+    # Dot-source is not possible since scripts use top-level params.
+    # Instead, test by invoking the script with mocked Az commands.
+
+    # Mock all Az module commands used by the cleanup scripts
+    function Get-AzSubscription { }
+    function Set-AzContext { }
+    function Get-AzResourceGroup { }
+    function Get-AzResource { }
+    function Get-AzResourceLock { }
+    function Remove-AzResourceGroup { }
+}
+
+Describe 'Remove-EmptyResourceGroups' {
+    BeforeEach {
+        # Default mocks
+        Mock Get-AzSubscription {
+            @([PSCustomObject]@{ Id = 'sub-1'; Name = 'Test Sub'; State = 'Enabled' })
+        }
+        Mock Set-AzContext { }
+        Mock Get-AzResourceLock { $null }
+        Mock Remove-AzResourceGroup { }
+    }
+
+    It 'should skip excluded resource groups' {
+        Mock Get-AzResourceGroup {
+            @(
+                [PSCustomObject]@{ ResourceGroupName = 'NetworkWatcherRG'; Location = 'eastus' },
+                [PSCustomObject]@{ ResourceGroupName = 'cloud-shell-storage-westus'; Location = 'westus' },
+                [PSCustomObject]@{ ResourceGroupName = 'my-test-rg'; Location = 'eastus' }
+            )
+        }
+        Mock Get-AzResource { @() }  # All RGs are empty
+
+        $results = & "$PSScriptRoot/../cleanup/Remove-EmptyResourceGroups.ps1" -WhatIf *>&1 |
+            Where-Object { $_ -match 'SKIP|WhatIf' }
+
+        # NetworkWatcherRG and cloud-shell-storage-* should be skipped
+        $results | Should -Not -BeNullOrEmpty
+        ($results | Where-Object { $_ -match 'NetworkWatcherRG' }).Count | Should -BeGreaterThan 0
+    }
+
+    It 'should not delete resource groups that contain resources' {
+        Mock Get-AzResourceGroup {
+            @([PSCustomObject]@{ ResourceGroupName = 'rg-with-stuff'; Location = 'eastus' })
+        }
+        Mock Get-AzResource {
+            @([PSCustomObject]@{ Name = 'some-resource'; ResourceType = 'Microsoft.Storage/storageAccounts' })
+        }
+
+        & "$PSScriptRoot/../cleanup/Remove-EmptyResourceGroups.ps1" -WhatIf *>&1 | Out-Null
+
+        Should -Invoke Remove-AzResourceGroup -Times 0
+    }
+
+    It 'should skip locked resource groups' {
+        Mock Get-AzResourceGroup {
+            @([PSCustomObject]@{ ResourceGroupName = 'locked-rg'; Location = 'eastus' })
+        }
+        Mock Get-AzResource { @() }  # Empty
+        Mock Get-AzResourceLock {
+            @([PSCustomObject]@{ Name = 'DoNotDelete'; Properties = @{ Level = 'CanNotDelete' } })
+        }
+
+        $output = & "$PSScriptRoot/../cleanup/Remove-EmptyResourceGroups.ps1" -WhatIf *>&1
+
+        Should -Invoke Remove-AzResourceGroup -Times 0
+        $output | Where-Object { $_ -match 'locked' } | Should -Not -BeNullOrEmpty
+    }
+}

--- a/tests/Remove-ExpiredResources.Tests.ps1
+++ b/tests/Remove-ExpiredResources.Tests.ps1
@@ -1,0 +1,77 @@
+BeforeAll {
+    function Get-AzSubscription { }
+    function Set-AzContext { param($SubscriptionId, $ErrorAction) }
+    function Get-AzResource { param($TagName, $ResourceId) }
+    function Get-AzResourceLock { param($ResourceId, $ErrorAction) }
+    function Remove-AzResource { param($ResourceId, [switch]$Force, $ErrorAction) }
+}
+
+Describe 'Remove-ExpiredResources' {
+    BeforeEach {
+        Mock Get-AzSubscription {
+            @([PSCustomObject]@{ Id = 'sub-1'; Name = 'Test Sub'; State = 'Enabled' })
+        }
+        Mock Set-AzContext { }
+        Mock Get-AzResourceLock { $null }
+        Mock Remove-AzResource { }
+    }
+
+    It 'should not have a -DryRun parameter (standardized to -WhatIf)' {
+        $cmd = Get-Command "$PSScriptRoot/../automation/Remove-ExpiredResources.ps1"
+        $cmd.Parameters.Keys | Should -Not -Contain 'DryRun'
+        $cmd.Parameters.Keys | Should -Contain 'WhatIf'
+    }
+
+    It 'should skip locked resources' {
+        # Return one expired resource regardless of which TagName is queried
+        Mock Get-AzResource {
+            if ($TagName -eq 'expiry-date') {
+                @([PSCustomObject]@{
+                    Id                = '/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm1'
+                    Name              = 'vm1'
+                    ResourceGroupName = 'rg'
+                    ResourceType      = 'Microsoft.Compute/virtualMachines'
+                    Tags              = @{ 'expiry-date' = '2025-01-01' }
+                })
+            } else { @() }
+        }
+
+        Mock Get-AzResourceLock {
+            @([PSCustomObject]@{ Name = 'CanNotDelete' })
+        }
+
+        $output = & "$PSScriptRoot/../automation/Remove-ExpiredResources.ps1" -WhatIf *>&1
+
+        Should -Invoke Remove-AzResource -Times 0
+        $output | Where-Object { $_ -match 'locked' } | Should -Not -BeNullOrEmpty
+    }
+
+    It 'should only process resources with expired dates' {
+        Mock Get-AzResource {
+            if ($TagName -eq 'expiry-date') {
+                @(
+                    [PSCustomObject]@{
+                        Id = '/sub/rg/providers/type/expired-resource'
+                        Name = 'expired-resource'
+                        ResourceGroupName = 'rg'
+                        ResourceType = 'Microsoft.Storage/storageAccounts'
+                        Tags = @{ 'expiry-date' = '2025-01-01' }
+                    },
+                    [PSCustomObject]@{
+                        Id = '/sub/rg/providers/type/future-resource'
+                        Name = 'future-resource'
+                        ResourceGroupName = 'rg'
+                        ResourceType = 'Microsoft.Storage/storageAccounts'
+                        Tags = @{ 'expiry-date' = '2099-12-31' }
+                    }
+                )
+            } else { @() }
+        }
+
+        $results = & "$PSScriptRoot/../automation/Remove-ExpiredResources.ps1" -WhatIf *>&1
+
+        # Expired resource should be processed, future resource should not
+        $results | Where-Object { $_ -match 'expired-resource' } | Should -Not -BeNullOrEmpty
+        $results | Where-Object { $_ -match 'future-resource' } | Should -BeNullOrEmpty
+    }
+}

--- a/tests/Remove-UnattachedDisks.Tests.ps1
+++ b/tests/Remove-UnattachedDisks.Tests.ps1
@@ -1,0 +1,70 @@
+BeforeAll {
+    function Get-AzSubscription { }
+    function Set-AzContext { }
+    function Get-AzDisk { }
+    function Get-AzResourceLock { }
+    function Remove-AzDisk { }
+    function New-AzSnapshotConfig { }
+    function New-AzSnapshot { }
+}
+
+Describe 'Remove-UnattachedDisks' {
+    BeforeEach {
+        Mock Get-AzSubscription {
+            @([PSCustomObject]@{ Id = 'sub-1'; Name = 'Test Sub'; State = 'Enabled' })
+        }
+        Mock Set-AzContext { }
+        Mock Get-AzResourceLock { $null }
+        Mock Remove-AzDisk { }
+    }
+
+    It 'should reject negative MinAgeDays' {
+        { & "$PSScriptRoot/../cleanup/Remove-UnattachedDisks.ps1" -MinAgeDays -5 -WhatIf } |
+            Should -Throw
+    }
+
+    It 'should reject MinAgeDays over 3650' {
+        { & "$PSScriptRoot/../cleanup/Remove-UnattachedDisks.ps1" -MinAgeDays 5000 -WhatIf } |
+            Should -Throw
+    }
+
+    It 'should skip disks newer than MinAgeDays' {
+        Mock Get-AzDisk {
+            @([PSCustomObject]@{
+                Name              = 'new-disk'
+                DiskState         = 'Unattached'
+                TimeCreated       = (Get-Date).AddDays(-5)  # Only 5 days old
+                DiskSizeGB        = 128
+                ResourceGroupName = 'rg-test'
+                Id                = '/subscriptions/sub-1/resourceGroups/rg-test/providers/Microsoft.Compute/disks/new-disk'
+                Location          = 'eastus'
+            })
+        }
+
+        & "$PSScriptRoot/../cleanup/Remove-UnattachedDisks.ps1" -MinAgeDays 30 -WhatIf *>&1 | Out-Null
+
+        Should -Invoke Remove-AzDisk -Times 0
+    }
+
+    It 'should skip locked disks' {
+        Mock Get-AzDisk {
+            @([PSCustomObject]@{
+                Name              = 'locked-disk'
+                DiskState         = 'Unattached'
+                TimeCreated       = (Get-Date).AddDays(-60)
+                DiskSizeGB        = 128
+                ResourceGroupName = 'rg-test'
+                Id                = '/subscriptions/sub-1/resourceGroups/rg-test/providers/Microsoft.Compute/disks/locked-disk'
+                Location          = 'eastus'
+            })
+        }
+        Mock Get-AzResourceLock {
+            @([PSCustomObject]@{ Name = 'DoNotDelete' })
+        }
+
+        $output = & "$PSScriptRoot/../cleanup/Remove-UnattachedDisks.ps1" -WhatIf *>&1
+
+        Should -Invoke Remove-AzDisk -Times 0
+        $output | Where-Object { $_ -match 'locked' } | Should -Not -BeNullOrEmpty
+    }
+}

--- a/tests/Tag-CleanupCandidates.Tests.ps1
+++ b/tests/Tag-CleanupCandidates.Tests.ps1
@@ -1,0 +1,16 @@
+Describe 'Tag-CleanupCandidates' {
+    It 'should reject non-existent CSV path' {
+        { & "$PSScriptRoot/../cleanup/Tag-CleanupCandidates.ps1" -InputCsv '/nonexistent/path.csv' -WhatIf } |
+            Should -Throw
+    }
+
+    It 'should reject GracePeriodDays less than 1' {
+        { & "$PSScriptRoot/../cleanup/Tag-CleanupCandidates.ps1" -GracePeriodDays 0 -WhatIf } |
+            Should -Throw
+    }
+
+    It 'should reject GracePeriodDays over 365' {
+        { & "$PSScriptRoot/../cleanup/Tag-CleanupCandidates.ps1" -GracePeriodDays 400 -WhatIf } |
+            Should -Throw
+    }
+}


### PR DESCRIPTION
## Summary

Complete v0.3.0 milestone — establishes quality gates for the toolkit.

### Changes

**Standardize dry-run (#10)**
- Removed custom `-DryRun` switch from `Remove-ExpiredResources.ps1`
- All cleanup scripts now consistently use `-WhatIf` via `SupportsShouldProcess`
- Updated `scheduled-cleanup.yml` to use `-WhatIf` instead of `-DryRun`

**Pester tests (#13)** — 13 tests across 4 files:
| Test File | Tests | What it covers |
|-----------|-------|---------------|
| Remove-EmptyResourceGroups | 3 | Exclusion patterns, non-empty RG skip, lock check |
| Remove-UnattachedDisks | 4 | ValidateRange (negative, over-limit), age filter, lock check |
| Remove-ExpiredResources | 3 | DryRun removal verification, lock check, expiry date filtering |
| Tag-CleanupCandidates | 3 | ValidateScript (bad path), ValidateRange (0, 400) |

**Pre-flight validation (#14)**
- New `automation/Test-Prerequisites.ps1` — checks Az modules, auth context, subscription access
- Added `preflight` job to both GitHub Actions workflows
- All jobs now `needs: preflight` — fail fast if prerequisites aren't met

## Test Results
```
Tests Passed: 13, Failed: 0, Skipped: 0
Tests completed in 970ms
```

## Test Plan
- [x] All 13 Pester tests pass
- [x] All PS1 files pass syntax validation
- [ ] Verify `-WhatIf` works on Remove-ExpiredResources (was `-DryRun`)

Closes #10, closes #13, closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)