### PR TITLE
feat: Prerequisites guide + metric-based staleness detection

### DIFF
--- a/discovery/Get-ResourceMetrics.ps1
+++ b/discovery/Get-ResourceMetrics.ps1
@@ -1,0 +1,208 @@
+<#
+.SYNOPSIS
+    Checks Azure Monitor metrics to identify unused resources.
+
+.DESCRIPTION
+    Queries Azure Monitor for utilization metrics on high-cost resource types.
+    Resources with zero or near-zero usage over the check period are flagged
+    as potentially stale. This catches resources that exist and run but are
+    never actually used — the most expensive form of waste.
+
+    Supported resource types:
+    - Virtual Machines (CPU percentage)
+    - App Service Plans (CPU percentage)
+    - SQL Databases (connection count)
+    - Storage Accounts (transaction count)
+    - Key Vaults (API hits)
+
+.PARAMETER SubscriptionId
+    Optional. Limit to a specific subscription.
+
+.PARAMETER CheckDays
+    Number of days to check metrics over. Default: 14.
+
+.PARAMETER OutputPath
+    Path to export CSV results. Default: ./metric-staleness.csv
+
+.PARAMETER ResourceTypes
+    Which resource types to check. Default: all supported types.
+
+.EXAMPLE
+    # Check all supported types over 14 days
+    .\Get-ResourceMetrics.ps1
+
+    # Quick check — VMs only, last 7 days
+    .\Get-ResourceMetrics.ps1 -ResourceTypes @('VirtualMachines') -CheckDays 7
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$SubscriptionId,
+
+    [Parameter()]
+    [ValidateRange(1, 90)]
+    [int]$CheckDays = 14,
+
+    [Parameter()]
+    [string]$OutputPath = "./metric-staleness.csv",
+
+    [Parameter()]
+    [ValidateSet('VirtualMachines', 'AppServicePlans', 'SqlDatabases', 'StorageAccounts', 'KeyVaults')]
+    [string[]]$ResourceTypes = @('VirtualMachines', 'AppServicePlans', 'SqlDatabases', 'StorageAccounts', 'KeyVaults')
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-Log {
+    param([string]$Message, [string]$Level = "INFO")
+    $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+    Write-Output "[$timestamp] [$Level] $Message"
+}
+
+# ── Metric definitions per resource type ──────────────────────────────────────
+
+$metricChecks = @{
+    VirtualMachines = @{
+        ResourceType = 'Microsoft.Compute/virtualMachines'
+        MetricName   = 'Percentage CPU'
+        Aggregation  = 'Average'
+        IdleThreshold = 5       # Avg CPU < 5% = likely idle
+        Label        = 'Avg CPU %'
+    }
+    AppServicePlans = @{
+        ResourceType = 'Microsoft.Web/serverFarms'
+        MetricName   = 'CpuPercentage'
+        Aggregation  = 'Average'
+        IdleThreshold = 2       # Avg CPU < 2% = likely idle
+        Label        = 'Avg CPU %'
+    }
+    SqlDatabases = @{
+        ResourceType = 'Microsoft.Sql/servers/databases'
+        MetricName   = 'connection_successful'
+        Aggregation  = 'Total'
+        IdleThreshold = 1       # 0 connections = unused
+        Label        = 'Total Connections'
+    }
+    StorageAccounts = @{
+        ResourceType = 'Microsoft.Storage/storageAccounts'
+        MetricName   = 'Transactions'
+        Aggregation  = 'Total'
+        IdleThreshold = 10      # < 10 transactions over period = effectively unused
+        Label        = 'Total Transactions'
+    }
+    KeyVaults = @{
+        ResourceType = 'Microsoft.KeyVault/vaults'
+        MetricName   = 'ServiceApiHit'
+        Aggregation  = 'Total'
+        IdleThreshold = 1       # 0 API hits = unused
+        Label        = 'Total API Hits'
+    }
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+Write-Log "Starting metric-based staleness check ($CheckDays-day window)"
+
+if ($SubscriptionId) {
+    $subscriptions = @(Get-AzSubscription -SubscriptionId $SubscriptionId)
+} else {
+    $subscriptions = Get-AzSubscription | Where-Object { $_.State -eq "Enabled" }
+}
+
+$startTime = (Get-Date).AddDays(-$CheckDays)
+$endTime = Get-Date
+$results = @()
+$totalChecked = 0
+$totalIdle = 0
+
+foreach ($sub in $subscriptions) {
+    Write-Log "Scanning subscription: $($sub.Name)"
+    Set-AzContext -SubscriptionId $sub.Id -ErrorAction Stop | Out-Null
+
+    foreach ($typeName in $ResourceTypes) {
+        $check = $metricChecks[$typeName]
+        if (-not $check) { continue }
+
+        Write-Log "  Checking $typeName ($($check.MetricName))..."
+
+        try {
+            $resources = Get-AzResource -ResourceType $check.ResourceType -ErrorAction Stop
+        } catch {
+            Write-Log "  Failed to list $typeName`: $_" -Level "ERROR"
+            continue
+        }
+
+        if ($resources.Count -eq 0) {
+            Write-Log "  No $typeName found"
+            continue
+        }
+
+        $idle = 0
+        foreach ($resource in $resources) {
+            $totalChecked++
+
+            try {
+                $metric = Get-AzMetric -ResourceId $resource.Id `
+                    -MetricName $check.MetricName `
+                    -StartTime $startTime -EndTime $endTime `
+                    -AggregationType $check.Aggregation `
+                    -TimeGrain ([TimeSpan]::FromDays(1)) `
+                    -WarningAction SilentlyContinue -ErrorAction Stop
+
+                $dataPoints = $metric.Data | Where-Object {
+                    $null -ne $_.($check.Aggregation)
+                }
+
+                $metricValue = if ($check.Aggregation -eq 'Average') {
+                    if ($dataPoints.Count -gt 0) {
+                        [math]::Round(($dataPoints | Measure-Object -Property Average -Average).Average, 2)
+                    } else { 0 }
+                } else {
+                    if ($dataPoints.Count -gt 0) {
+                        [math]::Round(($dataPoints | Measure-Object -Property Total -Sum).Sum, 0)
+                    } else { 0 }
+                }
+
+                $isIdle = $metricValue -lt $check.IdleThreshold
+
+                $results += [PSCustomObject]@{
+                    Subscription   = $sub.Name
+                    ResourceGroup  = $resource.ResourceGroupName
+                    ResourceName   = $resource.Name
+                    ResourceType   = $check.ResourceType
+                    MetricName     = $check.MetricName
+                    MetricValue    = $metricValue
+                    MetricLabel    = $check.Label
+                    Threshold      = $check.IdleThreshold
+                    IsIdle         = $isIdle
+                    CheckDays      = $CheckDays
+                    Tags           = ($resource.Tags | ConvertTo-Json -Compress -ErrorAction SilentlyContinue)
+                }
+
+                if ($isIdle) { $idle++ }
+            } catch {
+                # Some resources don't support metrics (e.g., master DB)
+                continue
+            }
+        }
+
+        Write-Log "  $typeName`: $($resources.Count) checked, $idle idle (below $($check.Label) threshold of $($check.IdleThreshold))"
+        $totalIdle += $idle
+    }
+}
+
+Write-Log "Metric check complete. Checked: $totalChecked | Idle: $totalIdle"
+
+if ($results.Count -gt 0) {
+    $results | Export-Csv -Path $OutputPath -NoTypeInformation
+    Write-Log "Results exported to: $OutputPath"
+
+    $idleResults = $results | Where-Object { $_.IsIdle }
+    if ($idleResults.Count -gt 0) {
+        Write-Log "Idle resources:"
+        $idleResults | Format-Table -AutoSize -Property ResourceName, ResourceType, MetricLabel, MetricValue, Threshold
+    }
+}
+
+return $results

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -1,0 +1,105 @@
+# Prerequisites
+
+## Runtime Requirements
+
+| Requirement | Minimum Version | Check Command |
+|-------------|----------------|---------------|
+| PowerShell | 7.x (Core) | `$PSVersionTable.PSVersion` |
+| Az.Accounts | 2.x | `Get-Module Az.Accounts -ListAvailable` |
+| Az.Monitor | 4.x | `Get-Module Az.Monitor -ListAvailable` |
+| Az.ResourceGraph | 0.13+ | `Get-Module Az.ResourceGraph -ListAvailable` |
+| ImportExcel | 7.x (optional) | `Get-Module ImportExcel -ListAvailable` |
+| Pester | 5.x (optional, for tests) | `Get-Module Pester -ListAvailable` |
+
+### Install Modules
+
+```powershell
+Install-Module Az -Scope CurrentUser -Force
+Install-Module ImportExcel -Scope CurrentUser  # For XLSX reports
+Install-Module Pester -Scope CurrentUser       # For running tests
+```
+
+## Required Permissions
+
+### Per-Script Permission Matrix
+
+| Script | Azure RBAC Role | Scope | Notes |
+|--------|----------------|-------|-------|
+| **Discovery** | | | |
+| `Invoke-TenantDiscovery.ps1` | Reader | Subscription | Activity Log access included |
+| `Get-OrphanedResources.ps1` | Reader | Subscription | Also needs Graph permissions (below) |
+| **Cleanup** | | | |
+| `Remove-EmptyResourceGroups.ps1` | Contributor | Subscription | Deletes empty RGs |
+| `Remove-UnattachedDisks.ps1` | Contributor | Subscription | Snapshot Contributor if using `-SnapshotBeforeDelete` |
+| `Remove-UnusedPublicIPs.ps1` | Contributor | Subscription | Deletes public IPs |
+| `Remove-ExpiredResources.ps1` | Contributor | Subscription | Deletes any tagged resource |
+| `Tag-CleanupCandidates.ps1` | Tag Contributor | Subscription | Only modifies tags |
+| **Cost** | | | |
+| Phase 3 (Cost Management API) | Cost Management Reader | Subscription | Or Billing Reader |
+| **Reporting** | | | |
+| `Export-DiscoveryReport.ps1` | None | Local | Reads CSV files only |
+
+### Entra ID / Microsoft Graph Permissions
+
+Required for Phase 4 (orphan detection) and `Get-OrphanedResources.ps1`:
+
+| Permission | Type | Why |
+|-----------|------|-----|
+| `User.Read.All` | Application or Delegated | Read `AccountEnabled` property for orphan detection |
+| `Directory.Read.All` | Application or Delegated | Enumerate all users in the tenant |
+
+**Without these permissions**, Phase 4 skips automatically with a warning. All other phases work normally.
+
+### Connecting with Required Scopes
+
+```powershell
+# Interactive login — basic discovery + cleanup
+Connect-AzAccount -Tenant yourtenant.com
+
+# With Graph scope — enables Entra ID orphan detection
+Connect-AzAccount -Tenant yourtenant.com -AuthScope 'https://graph.microsoft.com/.default'
+```
+
+### Service Principal for CI/CD
+
+```powershell
+# Create SP with Contributor role
+$sp = New-AzADServicePrincipal -DisplayName "Az-Dev-Cleanup-CI" -Role "Contributor" -Scope "/subscriptions/<sub-id>"
+
+# Add Cost Management Reader
+New-AzRoleAssignment -ObjectId $sp.Id -RoleDefinitionName "Cost Management Reader" -Scope "/subscriptions/<sub-id>"
+```
+
+Store in GitHub Actions secrets:
+- `AZURE_CLIENT_ID` — Application (client) ID
+- `AZURE_TENANT_ID` — Directory (tenant) ID
+- `AZURE_SUBSCRIPTION_ID` — Default subscription
+- `AZURE_CLIENT_SECRET` — Client secret (or use OIDC federated credentials)
+
+## Pre-flight Validation
+
+Run `automation/Test-Prerequisites.ps1` to verify all prerequisites:
+
+```powershell
+.\automation\Test-Prerequisites.ps1
+```
+
+Output:
+```
+[PASS] Az.Accounts module installed v2.19.0
+[PASS] Az.Monitor module installed v5.2.1
+[PASS] Azure context authenticated as user@tenant.com
+[PASS] Subscriptions accessible 2 enabled subscription(s)
+[PASS] Az.ResourceGraph module installed v0.13.0
+[PASS] ImportExcel module (optional) v7.8.10
+[PASS] Pester module (optional) v5.7.1
+
+[RESULT] All pre-flight checks passed
+```
+
+## GitHub Actions Setup
+
+1. Create a service principal (see above)
+2. Configure OIDC federated credentials (recommended over client secrets)
+3. Add secrets to the repository
+4. The `preflight` job in both workflows validates connectivity before running

--- a/reporting/Export-DiscoveryReport.ps1
+++ b/reporting/Export-DiscoveryReport.ps1
@@ -104,6 +104,7 @@ $worksheetMap = [ordered]@{
     "queries/20-sql-database-inventory"  = "SQL Databases"
     "resource-group-activity"            = "RG Activity"
     "resource-last-touch"                = "Resource Last Touch"
+    "metric-staleness"                   = "Metric Staleness"
     "cost-by-resource-group"             = "Cost by RG"
     "top-20-cost-resource-groups"        = "Top 20 Cost RGs"
     "orphaned-resource-groups"           = "Orphaned RGs"


### PR DESCRIPTION
## Summary

Final v0.4.0 items — documentation and the metric-based staleness scanner.

### Prerequisites Guide (#11)
`docs/prerequisites.md` with:
- Module version requirements (Az, ImportExcel, Pester)
- Per-script RBAC permission matrix
- Entra ID / Graph permission requirements
- Service principal setup for CI/CD
- Pre-flight validation instructions

### Metric-Based Staleness Detection (#21)
`discovery/Get-ResourceMetrics.ps1` — queries Azure Monitor for actual utilization:

| Resource Type | Metric | Idle Threshold |
|---|---|---|
| Virtual Machines | Percentage CPU | Avg < 5% |
| App Service Plans | CpuPercentage | Avg < 2% |
| SQL Databases | connection_successful | 0 connections |
| Storage Accounts | Transactions | < 10 transactions |
| Key Vaults | ServiceApiHit | 0 API hits |

Usage:
```powershell
# Check all types over 14 days
.\discovery\Get-ResourceMetrics.ps1

# Quick check — VMs only
.\discovery\Get-ResourceMetrics.ps1 -ResourceTypes VirtualMachines -CheckDays 7
```

Exports `metric-staleness.csv` → appears in XLSX report as "Metric Staleness" sheet.

## Test Plan
- [x] Run `Get-ResourceMetrics.ps1` against Procentrix Dev
- [x] Verify idle SQL databases and storage accounts are flagged
- [x] Verify metric-staleness.csv appears in XLSX report
- [x] Review prerequisites.md for accuracy

Closes #11, closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)