### PR TITLE
feat: Add Owner tag to RG cost sheets and scorecard

### DIFF
--- a/cleanup/Set-ResourceTags.ps1
+++ b/cleanup/Set-ResourceTags.ps1
@@ -1,0 +1,631 @@
+<#
+.SYNOPSIS
+    Applies tags to Azure resources using filters, CSV input, and optional rule-based mapping.
+
+.DESCRIPTION
+    A unified tagging tool that can apply any combination of tags to Azure resources
+    selected via CSV input, pipeline, or live query filters. Supports an optional JSON
+    rules file for conditional tag mapping based on resource properties.
+
+    Tags are always merged — existing tag values are never overwritten or removed.
+
+.PARAMETER Tags
+    Hashtable of explicit tag key-value pairs to apply. These take highest priority,
+    overriding rules and defaults.
+
+.PARAMETER InputCsv
+    Path to CSV file with a 'ResourceId' column (from discovery scripts).
+
+.PARAMETER ResourceId
+    Pipeline input — one or more Azure resource IDs.
+
+.PARAMETER ResourceType
+    Filter by Azure resource type (e.g., 'Microsoft.Compute/virtualMachines').
+    Supports wildcards.
+
+.PARAMETER ResourceGroup
+    Filter by resource group name. Supports wildcards.
+
+.PARAMETER Subscription
+    Filter by subscription name or ID.
+
+.PARAMETER Location
+    Filter by Azure region. Supports wildcards.
+
+.PARAMETER TagFilter
+    Filter by existing tag values (e.g., @{environment='dev'}).
+
+.PARAMETER Untagged
+    Select only resources with zero tags.
+
+.PARAMETER MissingTags
+    Select resources missing one or more specific tag keys.
+
+.PARAMETER MinAgeDays
+    Select resources older than N days (based on createdTime property).
+
+.PARAMETER RulesFile
+    Path to JSON rules file for conditional tag mapping.
+
+.PARAMETER BatchSize
+    Number of resources to process per batch. Pauses between batches for
+    confirmation unless -Force is specified. Default: 50.
+
+.PARAMETER SummaryOnly
+    Count matching resources grouped by type, subscription, and missing tags.
+    No tagging is performed.
+
+.PARAMETER Force
+    Skip batch pause confirmations.
+
+.EXAMPLE
+    # Tag all untagged resources with owner and project
+    .\Set-ResourceTags.ps1 -Untagged -Tags @{owner='platform-team'; project='infra'} -WhatIf
+
+.EXAMPLE
+    # Apply rules-based tagging to resources missing the owner tag
+    .\Set-ResourceTags.ps1 -MissingTags 'owner' -RulesFile ../policies/tagging-rules.json
+
+.EXAMPLE
+    # Tag resources from a discovery CSV
+    .\Set-ResourceTags.ps1 -InputCsv ./orphaned-resources.csv -Tags @{cleanup-status='candidate'; cleanup-date='+30d'}
+
+.EXAMPLE
+    # Summary of untagged resources without applying anything
+    .\Set-ResourceTags.ps1 -Untagged -SummaryOnly
+
+.EXAMPLE
+    # Pipeline input from another script
+    Get-OrphanedResources | .\Set-ResourceTags.ps1 -RulesFile ../policies/tagging-rules.json -Force
+#>
+
+[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'LiveQuery')]
+param(
+    [Parameter()]
+    [hashtable]$Tags,
+
+    [Parameter(Mandatory, ParameterSetName = 'CsvInput')]
+    [ValidateScript({ Test-Path $_ -PathType Leaf })]
+    [string]$InputCsv,
+
+    [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName, ParameterSetName = 'PipelineInput')]
+    [string[]]$ResourceId,
+
+    [Parameter(ParameterSetName = 'LiveQuery')]
+    [string]$ResourceType,
+
+    [Parameter(ParameterSetName = 'LiveQuery')]
+    [string]$ResourceGroup,
+
+    [Parameter(ParameterSetName = 'LiveQuery')]
+    [string]$Subscription,
+
+    [Parameter(ParameterSetName = 'LiveQuery')]
+    [string]$Location,
+
+    [Parameter(ParameterSetName = 'LiveQuery')]
+    [hashtable]$TagFilter,
+
+    [Parameter(ParameterSetName = 'LiveQuery')]
+    [switch]$Untagged,
+
+    [Parameter(ParameterSetName = 'LiveQuery')]
+    [string[]]$MissingTags,
+
+    [Parameter(ParameterSetName = 'LiveQuery')]
+    [ValidateRange(1, 3650)]
+    [int]$MinAgeDays,
+
+    [Parameter()]
+    [ValidateScript({ Test-Path $_ -PathType Leaf })]
+    [string]$RulesFile,
+
+    [Parameter()]
+    [ValidateRange(1, 1000)]
+    [int]$BatchSize = 50,
+
+    [Parameter()]
+    [switch]$SummaryOnly,
+
+    [Parameter()]
+    [switch]$Force
+)
+
+begin {
+    $ErrorActionPreference = "Stop"
+    $pipelineIds = [System.Collections.Generic.List[string]]::new()
+
+    # ── Logging ──────────────────────────────────────────────────────────────
+
+    function Write-Log {
+        param([string]$Message, [string]$Level = "INFO")
+        $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+        $color = switch ($Level) {
+            "TAG"   { "Green"  }
+            "SKIP"  { "DarkGray" }
+            "WARN"  { "Yellow" }
+            "ERROR" { "Red"    }
+            default { "White"  }
+        }
+        Write-Host "[$timestamp] [$Level] $Message" -ForegroundColor $color
+    }
+
+    # ── Rules Engine ─────────────────────────────────────────────────────────
+
+    function Import-TagRules {
+        param([string]$Path)
+
+        $content = Get-Content -Path $Path -Raw | ConvertFrom-Json -AsHashtable
+        if (-not $content.ContainsKey('rules') -or $content['rules'] -isnot [System.Collections.IList]) {
+            throw "Rules file must contain a 'rules' array: $Path"
+        }
+        foreach ($rule in $content['rules']) {
+            if (-not $rule.ContainsKey('name'))  { throw "Each rule must have a 'name' property" }
+            if (-not $rule.ContainsKey('match')) { throw "Rule '$($rule['name'])' must have a 'match' property" }
+            if (-not $rule.ContainsKey('tags'))  { throw "Rule '$($rule['name'])' must have a 'tags' property" }
+        }
+        return $content
+    }
+
+    function Test-PatternMatch {
+        param([string]$Value, [string]$Pattern)
+
+        if ($Pattern.StartsWith('regex:')) {
+            $regexPattern = $Pattern.Substring(6)
+            return $Value -match $regexPattern
+        }
+        return $Value -like $Pattern
+    }
+
+    function Test-RuleMatch {
+        param([hashtable]$Rule, [hashtable]$Resource)
+
+        $matchBlock = $Rule['match']
+        $matchMode  = if ($Rule.ContainsKey('matchMode')) { $Rule['matchMode'] } else { 'all' }
+        $results    = [System.Collections.Generic.List[bool]]::new()
+
+        if ($matchBlock.ContainsKey('resourceGroup')) {
+            $results.Add((Test-PatternMatch -Value $Resource['resourceGroup'] -Pattern $matchBlock['resourceGroup']))
+        }
+        if ($matchBlock.ContainsKey('resourceType')) {
+            $results.Add((Test-PatternMatch -Value $Resource['type'] -Pattern $matchBlock['resourceType']))
+        }
+        if ($matchBlock.ContainsKey('subscription')) {
+            $results.Add((Test-PatternMatch -Value $Resource['subscriptionName'] -Pattern $matchBlock['subscription']))
+        }
+        if ($matchBlock.ContainsKey('location')) {
+            $results.Add((Test-PatternMatch -Value $Resource['location'] -Pattern $matchBlock['location']))
+        }
+        if ($matchBlock.ContainsKey('hasTag')) {
+            $tagKey = $matchBlock['hasTag']
+            $hasTags = $Resource['tags'] -is [hashtable] -and $Resource['tags'].ContainsKey($tagKey)
+            $results.Add($hasTags)
+        }
+        if ($matchBlock.ContainsKey('missingTags')) {
+            $missing = $matchBlock['missingTags']
+            $resourceTags = if ($Resource['tags'] -is [hashtable]) { $Resource['tags'] } else { @{} }
+            $anyMissing = $false
+            foreach ($key in $missing) {
+                if (-not $resourceTags.ContainsKey($key)) { $anyMissing = $true; break }
+            }
+            $results.Add($anyMissing)
+        }
+        if ($matchBlock.ContainsKey('tagEquals')) {
+            $tagEquals = $matchBlock['tagEquals']
+            $resourceTags = if ($Resource['tags'] -is [hashtable]) { $Resource['tags'] } else { @{} }
+            $allEqual = $true
+            foreach ($key in $tagEquals.Keys) {
+                if (-not $resourceTags.ContainsKey($key) -or $resourceTags[$key] -ne $tagEquals[$key]) {
+                    $allEqual = $false; break
+                }
+            }
+            $results.Add($allEqual)
+        }
+        if ($matchBlock.ContainsKey('createdBy')) {
+            $createdBy = if ($Resource.ContainsKey('createdBy')) { $Resource['createdBy'] } else { '' }
+            $results.Add((Test-PatternMatch -Value $createdBy -Pattern $matchBlock['createdBy']))
+        }
+
+        if ($results.Count -eq 0) { return $false }
+
+        if ($matchMode -eq 'any') {
+            return ($results -contains $true)
+        }
+        return ($results -notcontains $false)
+    }
+
+    function Resolve-SpecialValue {
+        param([string]$Value, [hashtable]$Resource)
+
+        if ($Value -match '^\+(\d+)d$') {
+            return (Get-Date).AddDays([int]$Matches[1]).ToString("yyyy-MM-dd")
+        }
+
+        $resolved = $Value
+        $resolved = $resolved -creplace '\{today\}',         (Get-Date).ToString("yyyy-MM-dd")
+        $resolved = $resolved -creplace '\{createdBy\}',      ($Resource['createdBy'] ?? 'unknown')
+        $resolved = $resolved -creplace '\{resourceGroup\}',  ($Resource['resourceGroup'] ?? '')
+        $resolved = $resolved -creplace '\{subscription\}',   ($Resource['subscriptionName'] ?? '')
+
+        return $resolved
+    }
+
+    function Resolve-ResourceTags {
+        param(
+            [hashtable]$Resource,
+            [hashtable]$RulesConfig,
+            [hashtable]$ExplicitTags
+        )
+
+        $existingTags = if ($Resource['tags'] -is [hashtable]) {
+            [hashtable]$Resource['tags'].Clone()
+        } else { @{} }
+
+        $newTags = @{}
+
+        # 1. Evaluate rules (first match per key wins)
+        if ($null -ne $RulesConfig -and $RulesConfig.ContainsKey('rules')) {
+            foreach ($rule in $RulesConfig['rules']) {
+                if (Test-RuleMatch -Rule $rule -Resource $Resource) {
+                    foreach ($key in $rule['tags'].Keys) {
+                        if (-not $newTags.ContainsKey($key)) {
+                            $newTags[$key] = @{
+                                Value  = Resolve-SpecialValue -Value $rule['tags'][$key] -Resource $Resource
+                                Source = $rule['name']
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        # 2. Apply defaults (fill unset keys)
+        if ($null -ne $RulesConfig -and $RulesConfig.ContainsKey('defaults')) {
+            foreach ($key in $RulesConfig['defaults'].Keys) {
+                if (-not $newTags.ContainsKey($key)) {
+                    $newTags[$key] = @{
+                        Value  = Resolve-SpecialValue -Value $RulesConfig['defaults'][$key] -Resource $Resource
+                        Source = 'default'
+                    }
+                }
+            }
+        }
+
+        # 3. Apply explicit tags (override rules and defaults)
+        if ($null -ne $ExplicitTags) {
+            foreach ($key in $ExplicitTags.Keys) {
+                $newTags[$key] = @{
+                    Value  = Resolve-SpecialValue -Value ([string]$ExplicitTags[$key]) -Resource $Resource
+                    Source = 'explicit'
+                }
+            }
+        }
+
+        # 4. Compute diff — merge-only: skip keys that already exist
+        $diff = [System.Collections.Generic.List[hashtable]]::new()
+        foreach ($key in $newTags.Keys) {
+            if ($existingTags.ContainsKey($key)) {
+                $diff.Add(@{
+                    TagKey       = $key
+                    CurrentValue = $existingTags[$key]
+                    NewValue     = $newTags[$key].Value
+                    Source       = $newTags[$key].Source
+                    Action       = 'Skip'
+                })
+            } else {
+                $diff.Add(@{
+                    TagKey       = $key
+                    CurrentValue = $null
+                    NewValue     = $newTags[$key].Value
+                    Source       = $newTags[$key].Source
+                    Action       = 'Add'
+                })
+            }
+        }
+
+        return , $diff
+    }
+
+    # ── Live Query Builder ───────────────────────────────────────────────────
+
+    function Build-ResourceGraphQuery {
+        $clauses = [System.Collections.Generic.List[string]]::new()
+        $clauses.Add("resources")
+
+        if ($ResourceType) {
+            if ($ResourceType.Contains('*') -or $ResourceType.StartsWith('regex:')) {
+                $clauses.Add("| where type matches regex '(?i)$($ResourceType -replace '\*','.*')'")
+            } else {
+                $clauses.Add("| where type =~ '$ResourceType'")
+            }
+        }
+        if ($ResourceGroup) {
+            if ($ResourceGroup.Contains('*') -or $ResourceGroup.StartsWith('regex:')) {
+                $clauses.Add("| where resourceGroup matches regex '(?i)$($ResourceGroup -replace '\*','.*')'")
+            } else {
+                $clauses.Add("| where resourceGroup =~ '$ResourceGroup'")
+            }
+        }
+        if ($Location) {
+            if ($Location.Contains('*')) {
+                $clauses.Add("| where location matches regex '(?i)$($Location -replace '\*','.*')'")
+            } else {
+                $clauses.Add("| where location =~ '$Location'")
+            }
+        }
+        if ($Untagged) {
+            $clauses.Add("| where isnull(tags) or tags == '{}' or array_length(bag_keys(tags)) == 0")
+        }
+        if ($MissingTags) {
+            foreach ($tagKey in $MissingTags) {
+                $clauses.Add("| where not(tags contains '$tagKey')")
+            }
+        }
+        if ($TagFilter) {
+            foreach ($key in $TagFilter.Keys) {
+                $clauses.Add("| where tostring(tags['$key']) == '$($TagFilter[$key])'")
+            }
+        }
+        if ($MinAgeDays) {
+            $cutoffDate = (Get-Date).AddDays(-$MinAgeDays).ToString("yyyy-MM-ddTHH:mm:ssZ")
+            $clauses.Add("| where properties.createdTime < datetime('$cutoffDate')")
+        }
+
+        $clauses.Add("| project id, name, type, resourceGroup, subscriptionId, location, tags")
+
+        return ($clauses -join "`n")
+    }
+}
+
+process {
+    if ($PSCmdlet.ParameterSetName -eq 'PipelineInput' -and $ResourceId) {
+        foreach ($rid in $ResourceId) {
+            if (-not [string]::IsNullOrWhiteSpace($rid)) {
+                $pipelineIds.Add($rid)
+            }
+        }
+    }
+}
+
+end {
+    # ── Validate Inputs ──────────────────────────────────────────────────────
+
+    $hasInputSource = $false
+    $allResourceIds = [System.Collections.Generic.List[string]]::new()
+
+    # CSV Input
+    if ($InputCsv) {
+        $csv = Import-Csv -Path $InputCsv
+        $idColumn = ($csv[0].PSObject.Properties.Name | Where-Object { $_ -match '^(ResourceId|Id|resourceId)$' })[0]
+        if (-not $idColumn) {
+            Write-Log "CSV file must contain a 'ResourceId' or 'Id' column." -Level "ERROR"
+            return
+        }
+        foreach ($row in $csv) {
+            $rid = $row.$idColumn
+            if (-not [string]::IsNullOrWhiteSpace($rid)) { $allResourceIds.Add($rid) }
+        }
+        $hasInputSource = $true
+        Write-Log "Loaded $($allResourceIds.Count) resource(s) from CSV: $InputCsv"
+    }
+
+    # Pipeline Input
+    if ($pipelineIds.Count -gt 0) {
+        foreach ($rid in $pipelineIds) { $allResourceIds.Add($rid) }
+        $hasInputSource = $true
+        Write-Log "Received $($pipelineIds.Count) resource(s) from pipeline"
+    }
+
+    # Live Query
+    if ($PSCmdlet.ParameterSetName -eq 'LiveQuery') {
+        $hasFilter = $ResourceType -or $ResourceGroup -or $Subscription -or $Location -or
+                     $Untagged -or $MissingTags -or $TagFilter -or $MinAgeDays
+        if ($hasFilter) {
+            $kql = Build-ResourceGraphQuery
+            Write-Log "Querying Azure Resource Graph..."
+
+            $graphParams = @{ Query = $kql; First = 1000 }
+            if ($Subscription) {
+                $sub = Get-AzSubscription -SubscriptionName $Subscription -ErrorAction SilentlyContinue
+                if ($sub) { $graphParams['Subscription'] = $sub.Id }
+            }
+
+            $results = Search-AzGraph @graphParams
+            foreach ($r in $results) {
+                if (-not [string]::IsNullOrWhiteSpace($r.id)) { $allResourceIds.Add($r.id) }
+            }
+            $hasInputSource = $true
+            Write-Log "Resource Graph returned $($results.Count) resource(s)"
+        }
+    }
+
+    if (-not $hasInputSource -or $allResourceIds.Count -eq 0) {
+        Write-Log "No resources found. Provide -InputCsv, pipe ResourceId values, or specify filters." -Level "WARN"
+        return
+    }
+
+    # Deduplicate
+    $allResourceIds = [System.Collections.Generic.List[string]]($allResourceIds | Select-Object -Unique)
+    Write-Log "Total unique targets: $($allResourceIds.Count)"
+
+    # ── Summary Only Mode ────────────────────────────────────────────────────
+
+    if ($SummaryOnly) {
+        Write-Log "Summary mode — collecting resource metadata..."
+        $governanceTags = @('owner', 'project', 'environment', 'expiry-date')
+        $summaryData = [System.Collections.Generic.List[hashtable]]::new()
+
+        foreach ($rid in $allResourceIds) {
+            try {
+                $resource = Get-AzResource -ResourceId $rid -ErrorAction Stop
+                $existingTags = if ($null -ne $resource.Tags) { $resource.Tags } else { @{} }
+                $missing = $governanceTags | Where-Object { -not $existingTags.ContainsKey($_) }
+
+                $summaryData.Add(@{
+                    ResourceType = $resource.ResourceType
+                    Subscription = (($rid -split '/')[2])
+                    MissingTags  = ($missing -join ', ')
+                })
+            } catch {
+                Write-Log "Could not read resource: $rid — $_" -Level "WARN"
+            }
+        }
+
+        $grouped = $summaryData | Group-Object -Property ResourceType, Subscription
+        Write-Host ""
+        Write-Host "Resource Type                                  | Subscription                         | Count | Missing Tags" -ForegroundColor Cyan
+        Write-Host ("-" * 120) -ForegroundColor DarkGray
+        foreach ($group in $grouped) {
+            $parts = $group.Name -split ', '
+            $missingList = ($group.Group | ForEach-Object { $_.MissingTags } | Select-Object -Unique) -join '; '
+            Write-Host ("{0,-46} | {1,-36} | {2,5} | {3}" -f $parts[0], $parts[1], $group.Count, $missingList)
+        }
+        Write-Host ""
+        Write-Log "Summary complete. Total resources: $($allResourceIds.Count)"
+        return
+    }
+
+    # ── Validate Tag Source ──────────────────────────────────────────────────
+
+    if (-not $Tags -and -not $RulesFile) {
+        Write-Log "No tag source specified. Provide -Tags and/or -RulesFile." -Level "ERROR"
+        return
+    }
+
+    # ── Load Rules ───────────────────────────────────────────────────────────
+
+    $rulesConfig = $null
+    if ($RulesFile) {
+        $rulesConfig = Import-TagRules -Path $RulesFile
+        $ruleCount = $rulesConfig['rules'].Count
+        $defaultCount = if ($rulesConfig.ContainsKey('defaults')) { $rulesConfig['defaults'].Count } else { 0 }
+        Write-Log "Loaded $ruleCount rule(s) and $defaultCount default(s) from: $RulesFile"
+    }
+
+    # ── Process in Batches ───────────────────────────────────────────────────
+
+    $totalTagged  = 0
+    $totalSkipped = 0
+    $totalFailed  = 0
+    $outputRows   = [System.Collections.Generic.List[hashtable]]::new()
+    $batchCount   = [math]::Ceiling($allResourceIds.Count / $BatchSize)
+    $isWhatIf     = $WhatIfPreference
+
+    for ($batchIndex = 0; $batchIndex -lt $batchCount; $batchIndex++) {
+        $start = $batchIndex * $BatchSize
+        $end   = [math]::Min($start + $BatchSize, $allResourceIds.Count)
+        $batch = $allResourceIds[$start..($end - 1)]
+
+        Write-Log "Processing batch $($batchIndex + 1) of $batchCount ($($batch.Count) resources)..."
+
+        foreach ($rid in $batch) {
+            try {
+                $resource = Get-AzResource -ResourceId $rid -ErrorAction Stop
+                $resourceData = @{
+                    id               = $resource.ResourceId
+                    name             = $resource.Name
+                    type             = $resource.ResourceType
+                    resourceGroup    = $resource.ResourceGroupName
+                    location         = $resource.Location
+                    subscriptionName = (($rid -split '/')[2])
+                    tags             = if ($null -ne $resource.Tags) { $resource.Tags } else { @{} }
+                    createdBy        = ''
+                }
+
+                $diff = Resolve-ResourceTags -Resource $resourceData -RulesConfig $rulesConfig -ExplicitTags $Tags
+
+                $addTags = $diff | Where-Object { $_.Action -eq 'Add' }
+                if ($addTags.Count -eq 0) {
+                    Write-Log "[Skip] $($resource.Name) — no new tags to apply" -Level "SKIP"
+                    $totalSkipped++
+                    foreach ($d in $diff) {
+                        $outputRows.Add(@{
+                            ResourceId   = $rid
+                            ResourceName = $resource.Name
+                            TagKey       = $d.TagKey
+                            CurrentValue = $d.CurrentValue
+                            NewValue     = $d.NewValue
+                            Source       = $d.Source
+                            Status       = 'Skipped'
+                            Error        = ''
+                        })
+                    }
+                    continue
+                }
+
+                $tagsToMerge = @{}
+                foreach ($d in $addTags) { $tagsToMerge[$d.TagKey] = $d.NewValue }
+                $tagNames = ($addTags | ForEach-Object { $_.TagKey }) -join ', '
+
+                if ($PSCmdlet.ShouldProcess($rid, "Add tags: $tagNames")) {
+                    Update-AzTag -ResourceId $rid -Tag $tagsToMerge -Operation Merge -ErrorAction Stop | Out-Null
+                    Write-Log "[Tagged] $($resource.Name) — +$($addTags.Count) tags ($tagNames)" -Level "TAG"
+                    $totalTagged++
+                    $status = 'Tagged'
+                } else {
+                    Write-Log "[WhatIf] $($resource.Name) — would add $($addTags.Count) tags ($tagNames)" -Level "TAG"
+                    $totalTagged++
+                    $status = 'WhatIf'
+                }
+
+                foreach ($d in $diff) {
+                    $outputRows.Add(@{
+                        ResourceId   = $rid
+                        ResourceName = $resource.Name
+                        TagKey       = $d.TagKey
+                        CurrentValue = $d.CurrentValue
+                        NewValue     = $d.NewValue
+                        Source       = $d.Source
+                        Status       = if ($d.Action -eq 'Add') { $status } else { 'Skipped' }
+                        Error        = ''
+                    })
+                }
+            } catch {
+                Write-Log "[Failed] $rid — $_" -Level "ERROR"
+                $totalFailed++
+                $outputRows.Add(@{
+                    ResourceId   = $rid
+                    ResourceName = ''
+                    TagKey       = ''
+                    CurrentValue = ''
+                    NewValue     = ''
+                    Source       = ''
+                    Status       = 'Failed'
+                    Error        = $_.ToString()
+                })
+            }
+        }
+
+        # Batch pause (unless last batch, Force, or WhatIf)
+        if ($batchIndex -lt ($batchCount - 1) -and -not $Force -and -not $isWhatIf) {
+            $remaining = $allResourceIds.Count - $end
+            Write-Host ""
+            $response = Read-Host "Batch $($batchIndex + 1) complete. $remaining resources remaining. Continue? (Y/n)"
+            if ($response -and $response -notmatch '^[Yy]') {
+                Write-Log "User cancelled after batch $($batchIndex + 1)." -Level "WARN"
+                break
+            }
+        }
+    }
+
+    # ── Export Results ────────────────────────────────────────────────────────
+
+    $timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+    $prefix = if ($isWhatIf) { "tagging-preview" } else { "tagging-results" }
+    $outputPath = Join-Path -Path (Get-Location) -ChildPath "$prefix-$timestamp.csv"
+
+    if ($outputRows.Count -gt 0) {
+        $outputRows | ForEach-Object { [PSCustomObject]$_ } |
+            Select-Object ResourceId, ResourceName, TagKey, CurrentValue, NewValue, Source, Status, Error |
+            Export-Csv -Path $outputPath -NoTypeInformation
+        Write-Log "Results exported to: $outputPath"
+    }
+
+    # ── Summary ──────────────────────────────────────────────────────────────
+
+    Write-Host ""
+    Write-Host "═══════════════════════════════════════════════" -ForegroundColor Cyan
+    Write-Host "  Tagged: $totalTagged | Skipped: $totalSkipped | Failed: $totalFailed" -ForegroundColor White
+    Write-Host "═══════════════════════════════════════════════" -ForegroundColor Cyan
+    Write-Host ""
+}

--- a/discovery/Invoke-TenantDiscovery.ps1
+++ b/discovery/Invoke-TenantDiscovery.ps1
@@ -491,7 +491,36 @@ if (-not $SkipCostData) {
     Write-Log "  Phase 3 total: $([math]::Round($phase3Timer.Elapsed.TotalSeconds, 1))s"
 
     if ($costByRG.Count -gt 0) {
-        $costReport = $costByRG.Values | Sort-Object TotalCost -Descending
+        # Fetch RG owner tags from Resource Graph — non-fatal if unavailable
+        $rgOwnerMap = @{}
+        try {
+            $rgTagQuery = @'
+resourcecontainers
+| where type == "microsoft.resources/subscriptions/resourcegroups"
+| project subscriptionId, rg = name,
+          Owner = coalesce(tostring(tags.Owner), tostring(tags.owner))
+| where isnotempty(Owner)
+'@
+            $rgTagSkipToken = $null
+            do {
+                $rgTagParams = @{ Query = $rgTagQuery; First = 1000; Subscription = $subIds }
+                if ($rgTagSkipToken) { $rgTagParams.SkipToken = $rgTagSkipToken }
+                $rgTagPage = Search-AzGraph @rgTagParams
+                foreach ($r in $rgTagPage.Data) {
+                    $rgOwnerMap["$($r.subscriptionId)/$($r.rg)".ToLower()] = $r.Owner
+                }
+                $rgTagSkipToken = $rgTagPage.SkipToken
+            } while ($null -ne $rgTagSkipToken)
+            Write-Log "  RG owner tags: $($rgOwnerMap.Count) resource group(s) with owner tag"
+        } catch {
+            Write-Log "  RG owner tag lookup skipped (non-fatal): $_" -Level "WARN"
+        }
+
+        $costReport = $costByRG.Values | ForEach-Object {
+            $key = "$($_.SubscriptionId)/$($_.ResourceGroup)".ToLower()
+            $owner = if ($rgOwnerMap.ContainsKey($key)) { $rgOwnerMap[$key] } else { '' }
+            $_ | Add-Member -NotePropertyName Owner -NotePropertyValue $owner -PassThru
+        } | Sort-Object TotalCost -Descending
         $costReport | Export-Csv -Path "$OutputDir/cost-by-resource-group.csv" -NoTypeInformation
         Write-Log "Cost analysis: $($costReport.Count) resource groups"
 

--- a/docs/superpowers/specs/2026-04-04-unified-tagging-tool-design.md
+++ b/docs/superpowers/specs/2026-04-04-unified-tagging-tool-design.md
@@ -1,0 +1,245 @@
+# Unified Tagging Tool — `Set-ResourceTags.ps1`
+
+**Date:** 2026-04-04
+**Status:** Proposed
+**Location:** `cleanup/Set-ResourceTags.ps1`
+
+## Context
+
+The Az-Dev-Cleanup tenant has thousands of resources accumulated over 10+ years.
+Discovery identifies untagged and orphaned resources, but the only tagging tool
+(`Tag-CleanupCandidates.ps1`) is narrowly scoped — it applies three cleanup-specific
+tags to orphaned resources from a CSV. There is no general-purpose tool to assign
+governance tags (`owner`, `project`, `environment`) or arbitrary tags at scale using
+filters and conditional rules.
+
+**Goal:** A single PowerShell script that can apply any combination of tags to any
+set of Azure resources, selected via CSV input, pipeline, or live query filters,
+with optional rule-based conditional tag mapping.
+
+## Script Interface
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `-Tags` | `hashtable` | No* | — | Explicit tag key-value pairs to apply |
+| `-InputCsv` | `string` | No* | — | Path to CSV with `ResourceId` column |
+| `-ResourceId` | `string[]` | No* | — | Pipeline input — individual resource IDs |
+| `-ResourceType` | `string` | No | — | Filter: Azure resource type (supports wildcards) |
+| `-ResourceGroup` | `string` | No | — | Filter: resource group name (supports wildcards) |
+| `-Subscription` | `string` | No | — | Filter: subscription name or ID |
+| `-Location` | `string` | No | — | Filter: Azure region (supports wildcards) |
+| `-TagFilter` | `hashtable` | No | — | Filter: match resources by existing tag values |
+| `-Untagged` | `switch` | No | — | Filter: select only resources with zero tags |
+| `-MissingTags` | `string[]` | No | — | Filter: resources missing specific tag keys |
+| `-MinAgeDays` | `int` | No | — | Filter: resources older than N days |
+| `-RulesFile` | `string` | No | — | Path to JSON rules file for conditional mapping |
+| `-BatchSize` | `int` | No | 50 | Process N resources per batch; pause between batches |
+| `-SummaryOnly` | `switch` | No | — | Count matches grouped by type/sub/tag gap; no tagging |
+| `-Force` | `switch` | No | — | Skip batch pause confirmations |
+| `-WhatIf` | built-in | No | — | Preview mode — show diff, export CSV, apply nothing |
+| `-Confirm` | built-in | No | — | Prompt before each tag operation |
+
+*At least one **input source** required: `-InputCsv`, `-ResourceId`, or a live filter.
+*At least one **tag source** required: `-Tags` and/or `-RulesFile` (unless `-SummaryOnly`).
+
+### Parameter Sets
+
+- **CsvInput:** `-InputCsv` + optional filters + tag source
+- **PipelineInput:** `-ResourceId` (pipeline) + tag source
+- **LiveQuery:** One or more filters (`-ResourceType`, `-ResourceGroup`, `-Subscription`,
+  `-Location`, `-TagFilter`, `-Untagged`, `-MissingTags`, `-MinAgeDays`) + tag source
+
+All sets support `-RulesFile`, `-Tags`, `-BatchSize`, `-SummaryOnly`, `-Force`, `-WhatIf`.
+
+## Rules File Format
+
+Optional JSON file for conditional tag mapping. Rules are evaluated in order;
+first match per tag key wins.
+
+### Structure
+
+```json
+{
+  "rules": [
+    {
+      "name": "Production resources by RG pattern",
+      "matchMode": "all",
+      "match": {
+        "resourceGroup": "*-prod-*",
+        "location": "eastus"
+      },
+      "tags": {
+        "environment": "production",
+        "owner": "platform-team@contoso.com"
+      }
+    },
+    {
+      "name": "Multi-team dev resources",
+      "matchMode": "any",
+      "match": {
+        "resourceGroup": "regex:^(alpha|beta)-dev-",
+        "tagEquals": { "environment": "dev" }
+      },
+      "tags": {
+        "owner": "dev-leads@contoso.com",
+        "expiry-date": "+90d"
+      }
+    },
+    {
+      "name": "Unowned fallback",
+      "match": {
+        "missingTags": ["owner"]
+      },
+      "tags": {
+        "owner": "unassigned"
+      }
+    }
+  ],
+  "defaults": {
+    "project": "unknown",
+    "environment": "dev"
+  }
+}
+```
+
+### Match Conditions
+
+All conditions within a rule use AND logic by default (`"matchMode": "all"`).
+Set `"matchMode": "any"` for OR logic.
+
+| Condition | Type | Description |
+|-----------|------|-------------|
+| `resourceGroup` | string | Wildcard or `regex:` prefixed pattern |
+| `resourceType` | string | Wildcard or `regex:` prefixed pattern |
+| `subscription` | string | Name or ID, wildcard supported |
+| `location` | string | Azure region, wildcard supported |
+| `hasTag` | string | Resource has this tag key (any value) |
+| `missingTags` | string[] | Resource is missing one or more of these tag keys |
+| `tagEquals` | hashtable | Existing tag key matches exact value |
+| `createdBy` | string | Wildcard or regex on creator UPN (Activity Log) |
+
+### Special Tag Values
+
+| Syntax | Resolves To |
+|--------|-------------|
+| `+30d` | Today + 30 days, formatted `yyyy-MM-dd` |
+| `{createdBy}` | Resource creator's UPN (from Activity Log) |
+| `{resourceGroup}` | Resource group name |
+| `{subscription}` | Subscription name |
+| `{today}` | Today's date, formatted `yyyy-MM-dd` |
+
+### Evaluation Priority (highest to lowest)
+
+1. **Explicit `-Tags` parameter** — always wins
+2. **Rules** — first matching rule per tag key
+3. **Defaults** — fills in any remaining unset tag keys
+
+## Execution Flow
+
+```
+1. COLLECT TARGETS
+   ├── CSV input → parse ResourceId column
+   ├── Pipeline → collect ResourceId values
+   └── Live filters → Search-AzGraph KQL query
+   Combine all sources, deduplicate by ResourceId
+
+2. SUMMARY-ONLY CHECK
+   If -SummaryOnly: count by type/subscription/tag gap → display → exit
+
+3. LOAD RULES (if -RulesFile)
+   Parse JSON, validate schema, report rule count
+
+4. RESOLVE TAGS PER RESOURCE (in batches of -BatchSize)
+   For each resource:
+     a. Read existing tags (Get-AzResource)
+     b. Evaluate rules top-to-bottom (first match per key)
+     c. Apply defaults (fill gaps)
+     d. Apply explicit -Tags (override)
+     e. Merge with existing tags
+     f. Compute diff (new keys only — merge never overwrites)
+
+5. PREVIEW / APPLY
+   -WhatIf → color-coded diff table + export tagging-preview CSV
+   Live → Set-AzResource -Tag per resource, log results
+   Between batches: pause for confirmation (unless -Force)
+
+6. SUMMARY
+   Tagged: X | Skipped (no changes): Y | Failed: Z
+```
+
+## Tag Merge Behavior
+
+**Merge-only — never overwrites or removes existing tag values.**
+
+- If a resource already has `owner=TeamAlpha` and the tool resolves `owner=TeamBeta`,
+  the existing value is preserved and the tag is skipped (logged as "skipped — existing value").
+- New tag keys are always added.
+- To change an existing tag value, the user must first remove it manually (or via
+  `Update-AzTag -Operation Delete`) and then re-run the tool.
+
+## Output
+
+### Console
+
+- Progress bar with resource count and batch indicator
+- Per-resource line: `[Tagged] /subscriptions/.../myVM — +3 tags (owner, project, environment)`
+- Skipped resources: `[Skip] /subscriptions/.../myDB — no new tags to apply`
+- Final summary: `Tagged: 142 | Skipped: 38 | Failed: 2`
+
+### File Output
+
+| Mode | File | Columns |
+|------|------|---------|
+| `-WhatIf` | `tagging-preview-{timestamp}.csv` | ResourceId, TagKey, CurrentValue, NewValue, Source |
+| Live | `tagging-results-{timestamp}.csv` | ResourceId, TagKey, Value, Source, Status, Error |
+
+`Source` column values: rule name, `explicit`, or `default`.
+
+### SummaryOnly Output
+
+Table showing: ResourceType, Subscription, Count, MissingTags (comma-separated keys).
+
+## Live Query Implementation
+
+When using filter parameters without CSV/pipeline input, resources are queried
+via `Search-AzGraph` (Azure Resource Graph). The script builds a KQL query from
+the filter parameters:
+
+```kql
+resources
+| where type =~ "Microsoft.Compute/virtualMachines"   // -ResourceType
+| where resourceGroup matches regex ".*-prod-.*"       // -ResourceGroup
+| where location == "eastus"                           // -Location
+| where isnull(tags) or tags == "{}"                   // -Untagged
+| project id, name, type, resourceGroup, subscriptionId, location, tags
+```
+
+`-MinAgeDays` uses Activity Log (`Get-AzActivityLog`) to filter by creation date
+when Resource Graph `createdTime` is unavailable.
+
+## Integration with Existing Pipeline
+
+- **Replaces `Tag-CleanupCandidates.ps1` for complex tagging** — the existing script
+  remains for simple orphan-only tagging, but `Set-ResourceTags.ps1` can do the same
+  job with `-InputCsv orphaned-resources.csv -Tags @{cleanup-status='candidate'; cleanup-date='+30d'; cleanup-tagged-on='{today}'}`
+- **Consumes discovery output** — any CSV with a `ResourceId` column works
+- **Fits in `Invoke-CleanupDryRun.ps1`** — can be called with `-WhatIf` from orchestrator
+- **Rules files live in `policies/`** — alongside existing policy definitions, version-controlled
+
+## File Locations
+
+| File | Path |
+|------|------|
+| Script | `cleanup/Set-ResourceTags.ps1` |
+| Tests | `tests/Set-ResourceTags.Tests.ps1` |
+| Example rules | `policies/tagging-rules-example.json` |
+
+## Verification Plan
+
+1. **Unit tests** (Pester) — parameter validation, rule evaluation, tag merge logic, special value interpolation
+2. **WhatIf dry run** — run against real tenant with `-WhatIf`, verify preview CSV accuracy
+3. **Small batch test** — tag 5 resources in a test RG, verify merge behavior
+4. **Rules file test** — create rules matching known RG patterns, verify correct tag assignment
+5. **Integration test** — feed discovery CSV into the tool, verify end-to-end flow

--- a/policies/tagging-rules-example.json
+++ b/policies/tagging-rules-example.json
@@ -1,0 +1,82 @@
+{
+  "rules": [
+    {
+      "name": "Production resources by RG naming convention",
+      "matchMode": "all",
+      "match": {
+        "resourceGroup": "*-prod-*",
+        "location": "eastus"
+      },
+      "tags": {
+        "environment": "production",
+        "owner": "platform-team@contoso.com",
+        "project": "core-infrastructure"
+      }
+    },
+    {
+      "name": "Dev sandbox resources",
+      "matchMode": "all",
+      "match": {
+        "resourceGroup": "*-dev-*"
+      },
+      "tags": {
+        "environment": "dev",
+        "owner": "dev-leads@contoso.com",
+        "expiry-date": "+90d"
+      }
+    },
+    {
+      "name": "Multi-team staging (OR logic example)",
+      "matchMode": "any",
+      "match": {
+        "resourceGroup": "regex:^(alpha|beta|gamma)-staging-",
+        "tagEquals": { "environment": "staging" }
+      },
+      "tags": {
+        "environment": "staging",
+        "owner": "release-team@contoso.com"
+      }
+    },
+    {
+      "name": "VMs owned by their creator",
+      "matchMode": "all",
+      "match": {
+        "resourceType": "Microsoft.Compute/virtualMachines",
+        "missingTags": ["owner"]
+      },
+      "tags": {
+        "owner": "{createdBy}",
+        "cleanup-tagged-on": "{today}"
+      }
+    },
+    {
+      "name": "Storage accounts in specific subscription",
+      "matchMode": "all",
+      "match": {
+        "resourceType": "Microsoft.Storage/storageAccounts",
+        "subscription": "Dev-Test-Sub"
+      },
+      "tags": {
+        "project": "shared-storage",
+        "environment": "dev"
+      }
+    },
+    {
+      "name": "Unowned fallback — mark for review",
+      "matchMode": "all",
+      "match": {
+        "missingTags": ["owner"]
+      },
+      "tags": {
+        "owner": "unassigned",
+        "cleanup-status": "candidate",
+        "cleanup-date": "+30d",
+        "cleanup-tagged-on": "{today}"
+      }
+    }
+  ],
+  "defaults": {
+    "project": "unknown",
+    "environment": "dev"
+  }
+}

--- a/reporting/Export-DiscoveryReport.ps1
+++ b/reporting/Export-DiscoveryReport.ps1
@@ -291,6 +291,7 @@ if ($inventory.Count -gt 0) {
             $dormant = if ($dormantByRG.ContainsKey($rgLower)) { $dormantByRG[$rgLower] } else { 0 }
             $touched = if ($totalByRG.ContainsKey($rgLower)) { $totalByRG[$rgLower] } else { 0 }
             $dormantPct = if ($touched -gt 0) { [math]::Round(($dormant / $touched) * 100) } else { $null }
+            $owner = if ($cost -and $cost.Owner) { $cost.Owner } else { '' }
 
             [PSCustomObject]@{
                 ResourceGroup       = $rgName
@@ -299,6 +300,7 @@ if ($inventory.Count -gt 0) {
                 MonthlyCost         = $monthlyCost
                 DaysSinceActivity   = $lastActivityDays
                 LastCaller          = $lastCaller
+                Owner               = $owner
                 DormantResources    = $dormant
                 TouchedResources    = $touched
                 DormantPct          = $dormantPct

--- a/tests/Set-ResourceTags.Tests.ps1
+++ b/tests/Set-ResourceTags.Tests.ps1
@@ -1,0 +1,458 @@
+BeforeAll {
+    # Stub Az cmdlets so the script can be dot-sourced
+    function Get-AzResource { }
+    function Update-AzTag { }
+    function Search-AzGraph { }
+    function Get-AzSubscription { }
+
+    # Extract internal functions from the script using AST parsing
+    $scriptPath = "$PSScriptRoot/../cleanup/Set-ResourceTags.ps1"
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($scriptPath, [ref]$null, [ref]$null)
+
+    $functionsToExtract = @(
+        'Import-TagRules',
+        'Test-PatternMatch',
+        'Test-RuleMatch',
+        'Resolve-SpecialValue',
+        'Resolve-ResourceTags'
+    )
+
+    $functionDefs = $ast.FindAll({
+        param($node)
+        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $node.Name -in $functionsToExtract
+    }, $true)
+
+    foreach ($funcDef in $functionDefs) {
+        Invoke-Expression $funcDef.Extent.Text
+    }
+}
+
+# ── Parameter Validation ─────────────────────────────────────────────────────
+
+Describe 'Set-ResourceTags — Parameter Validation' {
+    It 'should reject non-existent CSV path' {
+        { & "$PSScriptRoot/../cleanup/Set-ResourceTags.ps1" -InputCsv '/nonexistent/path.csv' -Tags @{owner='test'} -WhatIf } |
+            Should -Throw
+    }
+
+    It 'should reject non-existent rules file path' {
+        { & "$PSScriptRoot/../cleanup/Set-ResourceTags.ps1" -Untagged -RulesFile '/nonexistent/rules.json' -WhatIf } |
+            Should -Throw
+    }
+
+    It 'should reject BatchSize less than 1' {
+        { & "$PSScriptRoot/../cleanup/Set-ResourceTags.ps1" -Untagged -Tags @{owner='test'} -BatchSize 0 -WhatIf } |
+            Should -Throw
+    }
+
+    It 'should reject BatchSize over 1000' {
+        { & "$PSScriptRoot/../cleanup/Set-ResourceTags.ps1" -Untagged -Tags @{owner='test'} -BatchSize 1001 -WhatIf } |
+            Should -Throw
+    }
+
+    It 'should reject MinAgeDays less than 1' {
+        { & "$PSScriptRoot/../cleanup/Set-ResourceTags.ps1" -MinAgeDays 0 -Tags @{owner='test'} -WhatIf } |
+            Should -Throw
+    }
+}
+
+# ── Test-PatternMatch ────────────────────────────────────────────────────────
+
+Describe 'Test-PatternMatch' {
+    It 'should match simple wildcard' {
+        Test-PatternMatch -Value 'rg-prod-eastus' -Pattern '*-prod-*' | Should -BeTrue
+    }
+
+    It 'should not match non-matching wildcard' {
+        Test-PatternMatch -Value 'rg-dev-eastus' -Pattern '*-prod-*' | Should -BeFalse
+    }
+
+    It 'should match regex pattern' {
+        Test-PatternMatch -Value 'alpha-staging-01' -Pattern 'regex:^(alpha|beta)-staging-' | Should -BeTrue
+    }
+
+    It 'should not match non-matching regex' {
+        Test-PatternMatch -Value 'gamma-staging-01' -Pattern 'regex:^(alpha|beta)-staging-' | Should -BeFalse
+    }
+
+    It 'should match exact string with no wildcards' {
+        Test-PatternMatch -Value 'eastus' -Pattern 'eastus' | Should -BeTrue
+    }
+}
+
+# ── Test-RuleMatch ───────────────────────────────────────────────────────────
+
+Describe 'Test-RuleMatch' {
+    BeforeAll {
+        $testResource = @{
+            id               = '/subscriptions/sub-1/resourceGroups/rg-prod-eastus/providers/Microsoft.Compute/virtualMachines/vm1'
+            name             = 'vm1'
+            type             = 'Microsoft.Compute/virtualMachines'
+            resourceGroup    = 'rg-prod-eastus'
+            location         = 'eastus'
+            subscriptionName = 'sub-1'
+            tags             = @{ environment = 'production' }
+            createdBy        = 'user@contoso.com'
+        }
+    }
+
+    It 'should match with AND logic (all conditions true)' {
+        $rule = @{
+            name  = 'test'
+            matchMode = 'all'
+            match = @{
+                resourceGroup = '*-prod-*'
+                location      = 'eastus'
+            }
+            tags  = @{ owner = 'test' }
+        }
+        Test-RuleMatch -Rule $rule -Resource $testResource | Should -BeTrue
+    }
+
+    It 'should not match AND logic when one condition fails' {
+        $rule = @{
+            name  = 'test'
+            matchMode = 'all'
+            match = @{
+                resourceGroup = '*-prod-*'
+                location      = 'westus'
+            }
+            tags  = @{ owner = 'test' }
+        }
+        Test-RuleMatch -Rule $rule -Resource $testResource | Should -BeFalse
+    }
+
+    It 'should match with OR logic when one condition is true' {
+        $rule = @{
+            name  = 'test'
+            matchMode = 'any'
+            match = @{
+                resourceGroup = '*-dev-*'
+                location      = 'eastus'
+            }
+            tags  = @{ owner = 'test' }
+        }
+        Test-RuleMatch -Rule $rule -Resource $testResource | Should -BeTrue
+    }
+
+    It 'should not match OR logic when all conditions fail' {
+        $rule = @{
+            name  = 'test'
+            matchMode = 'any'
+            match = @{
+                resourceGroup = '*-dev-*'
+                location      = 'westus'
+            }
+            tags  = @{ owner = 'test' }
+        }
+        Test-RuleMatch -Rule $rule -Resource $testResource | Should -BeFalse
+    }
+
+    It 'should default to AND matchMode when not specified' {
+        $rule = @{
+            name  = 'test'
+            match = @{
+                resourceGroup = '*-prod-*'
+                location      = 'westus'
+            }
+            tags  = @{ owner = 'test' }
+        }
+        Test-RuleMatch -Rule $rule -Resource $testResource | Should -BeFalse
+    }
+
+    It 'should match missingTags condition' {
+        $rule = @{
+            name  = 'test'
+            match = @{ missingTags = @('owner', 'project') }
+            tags  = @{ owner = 'test' }
+        }
+        Test-RuleMatch -Rule $rule -Resource $testResource | Should -BeTrue
+    }
+
+    It 'should not match missingTags when all tags present' {
+        $rule = @{
+            name  = 'test'
+            match = @{ missingTags = @('environment') }
+            tags  = @{ owner = 'test' }
+        }
+        Test-RuleMatch -Rule $rule -Resource $testResource | Should -BeFalse
+    }
+
+    It 'should match hasTag condition' {
+        $rule = @{
+            name  = 'test'
+            match = @{ hasTag = 'environment' }
+            tags  = @{ owner = 'test' }
+        }
+        Test-RuleMatch -Rule $rule -Resource $testResource | Should -BeTrue
+    }
+
+    It 'should match tagEquals condition' {
+        $rule = @{
+            name  = 'test'
+            match = @{ tagEquals = @{ environment = 'production' } }
+            tags  = @{ owner = 'test' }
+        }
+        Test-RuleMatch -Rule $rule -Resource $testResource | Should -BeTrue
+    }
+
+    It 'should not match tagEquals with wrong value' {
+        $rule = @{
+            name  = 'test'
+            match = @{ tagEquals = @{ environment = 'dev' } }
+            tags  = @{ owner = 'test' }
+        }
+        Test-RuleMatch -Rule $rule -Resource $testResource | Should -BeFalse
+    }
+
+    It 'should match createdBy condition' {
+        $rule = @{
+            name  = 'test'
+            match = @{ createdBy = '*@contoso.com' }
+            tags  = @{ owner = 'test' }
+        }
+        Test-RuleMatch -Rule $rule -Resource $testResource | Should -BeTrue
+    }
+
+    It 'should match resourceType condition' {
+        $rule = @{
+            name  = 'test'
+            match = @{ resourceType = 'Microsoft.Compute/*' }
+            tags  = @{ owner = 'test' }
+        }
+        Test-RuleMatch -Rule $rule -Resource $testResource | Should -BeTrue
+    }
+
+    It 'should return false when match block is empty' {
+        $rule = @{
+            name  = 'test'
+            match = @{}
+            tags  = @{ owner = 'test' }
+        }
+        Test-RuleMatch -Rule $rule -Resource $testResource | Should -BeFalse
+    }
+}
+
+# ── Resolve-SpecialValue ────────────────────────────────────────────────────
+
+Describe 'Resolve-SpecialValue' {
+    BeforeAll {
+        $testResource = @{
+            createdBy        = 'alice@contoso.com'
+            resourceGroup    = 'rg-prod-01'
+            subscriptionName = 'Production'
+        }
+    }
+
+    It 'should resolve relative date +30d' {
+        $result = Resolve-SpecialValue -Value '+30d' -Resource $testResource
+        $expected = (Get-Date).AddDays(30).ToString("yyyy-MM-dd")
+        $result | Should -Be $expected
+    }
+
+    It 'should resolve relative date +90d' {
+        $result = Resolve-SpecialValue -Value '+90d' -Resource $testResource
+        $expected = (Get-Date).AddDays(90).ToString("yyyy-MM-dd")
+        $result | Should -Be $expected
+    }
+
+    It 'should resolve {today} placeholder' {
+        $result = Resolve-SpecialValue -Value '{today}' -Resource $testResource
+        $expected = (Get-Date).ToString("yyyy-MM-dd")
+        $result | Should -Be $expected
+    }
+
+    It 'should resolve {createdBy} placeholder' {
+        $result = Resolve-SpecialValue -Value '{createdBy}' -Resource $testResource
+        $result | Should -Be 'alice@contoso.com'
+    }
+
+    It 'should resolve {resourceGroup} placeholder' {
+        $result = Resolve-SpecialValue -Value '{resourceGroup}' -Resource $testResource
+        $result | Should -Be 'rg-prod-01'
+    }
+
+    It 'should resolve {subscription} placeholder' {
+        $result = Resolve-SpecialValue -Value '{subscription}' -Resource $testResource
+        $result | Should -Be 'Production'
+    }
+
+    It 'should return plain strings unchanged' {
+        $result = Resolve-SpecialValue -Value 'platform-team@contoso.com' -Resource $testResource
+        $result | Should -Be 'platform-team@contoso.com'
+    }
+
+    It 'should default createdBy to unknown when missing' {
+        $resource = @{ resourceGroup = 'rg1'; subscriptionName = 'sub1' }
+        $result = Resolve-SpecialValue -Value '{createdBy}' -Resource $resource
+        $result | Should -Be 'unknown'
+    }
+}
+
+# ── Resolve-ResourceTags ────────────────────────────────────────────────────
+
+Describe 'Resolve-ResourceTags' {
+    It 'should apply explicit tags' {
+        $resource = @{
+            type          = 'Microsoft.Compute/virtualMachines'
+            resourceGroup = 'rg-test'
+            location      = 'eastus'
+            tags          = @{}
+        }
+        $diff = Resolve-ResourceTags -Resource $resource -RulesConfig $null -ExplicitTags @{ owner = 'alice' }
+        $diff.Count | Should -Be 1
+        $diff[0].TagKey | Should -Be 'owner'
+        $diff[0].NewValue | Should -Be 'alice'
+        $diff[0].Source | Should -Be 'explicit'
+        $diff[0].Action | Should -Be 'Add'
+    }
+
+    It 'should skip tags that already exist (merge-only)' {
+        $resource = @{
+            type          = 'Microsoft.Compute/virtualMachines'
+            resourceGroup = 'rg-test'
+            location      = 'eastus'
+            tags          = @{ owner = 'existing-owner' }
+        }
+        $diff = Resolve-ResourceTags -Resource $resource -RulesConfig $null -ExplicitTags @{ owner = 'new-owner' }
+        $diff.Count | Should -Be 1
+        $diff[0].Action | Should -Be 'Skip'
+        $diff[0].CurrentValue | Should -Be 'existing-owner'
+    }
+
+    It 'should apply rules when no explicit tags given' {
+        $resource = @{
+            type          = 'Microsoft.Compute/virtualMachines'
+            resourceGroup = 'rg-prod-eastus'
+            location      = 'eastus'
+            tags          = @{}
+        }
+        $rulesConfig = @{
+            rules = @(
+                @{
+                    name  = 'prod-rule'
+                    match = @{ resourceGroup = '*-prod-*' }
+                    tags  = @{ environment = 'production' }
+                }
+            )
+        }
+        $diff = Resolve-ResourceTags -Resource $resource -RulesConfig $rulesConfig -ExplicitTags $null
+        $match = $diff | Where-Object { $_.TagKey -eq 'environment' }
+        $match.NewValue | Should -Be 'production'
+        $match.Source | Should -Be 'prod-rule'
+    }
+
+    It 'should apply defaults for unset keys' {
+        $resource = @{
+            type          = 'Microsoft.Compute/virtualMachines'
+            resourceGroup = 'rg-test'
+            location      = 'eastus'
+            tags          = @{}
+        }
+        $rulesConfig = @{
+            rules    = @()
+            defaults = @{ project = 'unknown'; environment = 'dev' }
+        }
+        $diff = Resolve-ResourceTags -Resource $resource -RulesConfig $rulesConfig -ExplicitTags $null
+        $diff.Count | Should -Be 2
+        ($diff | Where-Object { $_.TagKey -eq 'project' }).Source | Should -Be 'default'
+    }
+
+    It 'should prioritize explicit over rules over defaults' {
+        $resource = @{
+            type          = 'Microsoft.Compute/virtualMachines'
+            resourceGroup = 'rg-prod-eastus'
+            location      = 'eastus'
+            tags          = @{}
+        }
+        $rulesConfig = @{
+            rules = @(
+                @{
+                    name  = 'prod-rule'
+                    match = @{ resourceGroup = '*-prod-*' }
+                    tags  = @{ owner = 'rule-owner' }
+                }
+            )
+            defaults = @{ owner = 'default-owner' }
+        }
+        $diff = Resolve-ResourceTags -Resource $resource -RulesConfig $rulesConfig -ExplicitTags @{ owner = 'explicit-owner' }
+        $match = $diff | Where-Object { $_.TagKey -eq 'owner' }
+        $match.NewValue | Should -Be 'explicit-owner'
+        $match.Source | Should -Be 'explicit'
+    }
+
+    It 'first matching rule per key wins' {
+        $resource = @{
+            type          = 'Microsoft.Compute/virtualMachines'
+            resourceGroup = 'rg-prod-eastus'
+            location      = 'eastus'
+            tags          = @{}
+        }
+        $rulesConfig = @{
+            rules = @(
+                @{
+                    name  = 'rule-1'
+                    match = @{ resourceGroup = '*-prod-*' }
+                    tags  = @{ owner = 'first-owner' }
+                },
+                @{
+                    name  = 'rule-2'
+                    match = @{ location = 'eastus' }
+                    tags  = @{ owner = 'second-owner' }
+                }
+            )
+        }
+        $diff = Resolve-ResourceTags -Resource $resource -RulesConfig $rulesConfig -ExplicitTags $null
+        $match = $diff | Where-Object { $_.TagKey -eq 'owner' }
+        $match.NewValue | Should -Be 'first-owner'
+        $match.Source | Should -Be 'rule-1'
+    }
+}
+
+# ── Import-TagRules Validation ───────────────────────────────────────────────
+
+Describe 'Import-TagRules — Validation' {
+    It 'should reject rules file without rules array' {
+        $tmpFile = [System.IO.Path]::GetTempFileName()
+        '{"defaults": {}}' | Set-Content -Path $tmpFile
+        { Import-TagRules -Path $tmpFile } | Should -Throw "*'rules' array*"
+        Remove-Item -Path $tmpFile
+    }
+
+    It 'should reject rule without name' {
+        $tmpFile = [System.IO.Path]::GetTempFileName()
+        '{"rules": [{"match": {}, "tags": {}}]}' | Set-Content -Path $tmpFile
+        { Import-TagRules -Path $tmpFile } | Should -Throw "*'name'*"
+        Remove-Item -Path $tmpFile
+    }
+
+    It 'should reject rule without match' {
+        $tmpFile = [System.IO.Path]::GetTempFileName()
+        '{"rules": [{"name": "test", "tags": {}}]}' | Set-Content -Path $tmpFile
+        { Import-TagRules -Path $tmpFile } | Should -Throw "*'match'*"
+        Remove-Item -Path $tmpFile
+    }
+
+    It 'should reject rule without tags' {
+        $tmpFile = [System.IO.Path]::GetTempFileName()
+        '{"rules": [{"name": "test", "match": {}}]}' | Set-Content -Path $tmpFile
+        { Import-TagRules -Path $tmpFile } | Should -Throw "*'tags'*"
+        Remove-Item -Path $tmpFile
+    }
+
+    It 'should load valid rules file' {
+        $tmpFile = [System.IO.Path]::GetTempFileName()
+        $json = @{
+            rules = @(
+                @{ name = 'test'; match = @{ resourceGroup = '*' }; tags = @{ owner = 'test' } }
+            )
+            defaults = @{ project = 'unknown' }
+        } | ConvertTo-Json -Depth 5
+        $json | Set-Content -Path $tmpFile
+        $result = Import-TagRules -Path $tmpFile
+        $result['rules'].Count | Should -Be 1
+        $result['defaults']['project'] | Should -Be 'unknown'
+        Remove-Item -Path $tmpFile
+    }
+}


### PR DESCRIPTION
## Summary

- Fetches RG-level `Owner` tags from Azure Resource Graph (`resourcecontainers`) during Phase 3 cost analysis in `Invoke-TenantDiscovery.ps1`
- Injects `Owner` column into `cost-by-resource-group.csv` and `top-20-cost-resource-groups.csv` — picked up automatically by the Excel export loop
- Adds `Owner` field to the **RG Scorecard** sheet (between `LastCaller` and `DormantResources`) by reading from the enriched cost CSV

## Behavior

- Handles both `tags.Owner` and `tags.owner` casing via KQL `coalesce`
- Lookup key is `subscriptionId/resourceGroup` (lowercased) — safe across multi-subscription tenants
- **Non-fatal**: if the Resource Graph call fails (e.g. missing permissions), a WARN is logged and `Owner` is blank — the rest of the report is unaffected
- Fully paginated (`SkipToken` loop) to handle tenants with large numbers of RGs

## Test plan

- [ ] Run `Invoke-TenantDiscovery.ps1` — confirm `cost-by-resource-group.csv` and `top-20-cost-resource-groups.csv` have an `Owner` column with values where the tag is set
- [ ] Run `Export-DiscoveryReport.ps1` — confirm **Top 20 Cost RGs**, **Cost by RG**, and **RG Scorecard** sheets all show the `Owner` column
- [ ] Verify blank `Owner` (not missing column) when no RGs have the tag
- [ ] Verify report completes without error when Resource Graph tag lookup fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)